### PR TITLE
add dotnet to lists

### DIFF
--- a/src/lists.js
+++ b/src/lists.js
@@ -82,6 +82,16 @@ export default {
       this.querySelector("#toc-table-of-contents").style.display = "none";
     },
   },
+  "quozd/awesome-dotnet": {
+    slug: "dotnet",
+    label: ".NET",
+    description:
+      ".NET is a developer platform with tools and libraries for building any type of app, including web, mobile, desktop, games, IoT, cloud, and microservices.",
+    logo: "https://avatars.githubusercontent.com/dotnet",
+    color: "#512bd4",
+    category: "Programming Languages",
+    mutateContent() {},
+  },
   "avelino/awesome-go": {
     slug: "go",
     label: "Go",


### PR DESCRIPTION
As there does not seem to be a separate list for C# I propose adding the .NET list instead - it's very much focused on C# anyway and thus should get along with the existing F# list very well.