### PR TITLE
change the wording of the Girls section to something more appropriate

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,6 +25,18 @@ const App = () => (
           />
         ))}
 
+        {Object.entries(lists)
+          // allow alternative slugs to not lose old deep links to now-changed list entries
+          .filter(([_, list]) => !!list.alternativeSlug)
+          .map(([fullName, list]) => (
+            <Route
+              exact
+              key={list.alternativeSlug}
+              path={`/${list.alternativeSlug}`}
+              component={() => <Redirect to={`/${fullName}`} />}
+            />
+          ))}
+
         <Route component={NotFound} />
       </Switch>
     </Fragment>

--- a/src/lists.js
+++ b/src/lists.js
@@ -1306,8 +1306,9 @@ export default {
     },
   },
   "cristianoliveira/awesome4girls": {
-    slug: "for-girls",
-    label: "For Girls",
+    slug: "for-women",
+    alternativeSlug: "for-girls",
+    label: "For Women",
     description:
       "A curated list of inclusive events, projects and initiatives for women in the tech area.",
     category: "Miscellaneous",


### PR DESCRIPTION
As per the reddit discussion at (https://www.reddit.com/r/InternetIsBeautiful/comments/j2kafw/list_community_an_easy_way_to_browse_curated/g763csz/) I propose changing the word "Girls" into the more appropriate "Women".

To make old deep links work I also added a very simple mechanism to allow two slugs to go to the same awesome-list without showing up twice.